### PR TITLE
Add abbreviations

### DIFF
--- a/ftplugin/lean.vim
+++ b/ftplugin/lean.vim
@@ -1,0 +1,22 @@
+"Without this, abbreviations starting with backslash can have at most one
+"character
+setlocal iskeyword+=\
+
+" Add some common abbreviations
+inoreabbrev <buffer> \pi Π
+inoreabbrev <buffer> \Pi Π
+inoreabbrev <buffer> \forall ∀
+inoreabbrev <buffer> \exists ∃
+inoreabbrev <buffer> \N ℕ
+inoreabbrev <buffer> \a α
+inoreabbrev <buffer> \b β
+inoreabbrev <buffer> \g γ
+inoreabbrev <buffer> \to →
+inoreabbrev <buffer> \S Σ
+inoreabbrev <buffer> \sigma Σ
+inoreabbrev <buffer> \not ¬
+inoreabbrev <buffer> \l λ
+inoreabbrev <buffer> \from ←
+inoreabbrev <buffer> \and ∧
+inoreabbrev <buffer> \or ∨
+inoreabbrev <buffer> \fun λ

--- a/ftplugin/lean.vim
+++ b/ftplugin/lean.vim
@@ -1,6 +1,9 @@
-"Without this, abbreviations starting with backslash can have at most one
-"character
-setlocal iskeyword+=\
+" The backslash is needed here to allow the abbreviations
+setlocal iskeyword+=@,48-57,_,-,!,#,$,%,\
+
+" tabs = evil
+set expandtab
+
 
 " Add some common abbreviations
 inoreabbrev <buffer> \pi Π

--- a/syntax/lean.vim
+++ b/syntax/lean.vim
@@ -3,11 +3,6 @@
 " Filename extensions:	*.lean
 " Maintainer:           Gabriel Ebner
 
-setlocal iskeyword+=@,48-57,_,-,!,#,$,%
-
-" tabs = evil
-set expandtab
-
 syn case match
 
 " keywords

--- a/syntax/lean.vim
+++ b/syntax/lean.vim
@@ -3,7 +3,7 @@
 " Filename extensions:	*.lean
 " Maintainer:           Gabriel Ebner
 
-setlocal iskeyword=@,48-57,_,-,!,#,$,%
+setlocal iskeyword+=@,48-57,_,-,!,#,$,%
 
 " tabs = evil
 set expandtab


### PR DESCRIPTION
This allows vim to replace \pi with Π and similar. Firstly, to allow abbreviations with \\, we need to add \\ to iskeyword, so I modified the syntax file to only append to iskeyword rather than resetting it. Then in ftplugin/lean.vim we actually add \ to iskeyword, and create the abbreviations. I think I caught the useful ones, happy to add more if needed though.