### PR TITLE
Set textwidth by default to mathlib's style recommendation.

### DIFF
--- a/ftplugin/lean.vim
+++ b/ftplugin/lean.vim
@@ -5,6 +5,8 @@ let b:did_ftplugin = 1
 
 setlocal iskeyword=@,48-57,_,-,!,#,$,%
 
+setlocal textwidth=100
+
 setlocal comments=s0:/-,mb:\ ,ex:-/,:--
 setlocal commentstring=/-\ %s\ -/
 


### PR DESCRIPTION
See https://leanprover-community.github.io/contribute/style.html#line-length