### PR TITLE
Ignore oleans by default in wildignore

### DIFF
--- a/ftplugin/lean.vim
+++ b/ftplugin/lean.vim
@@ -3,6 +3,8 @@ if exists('b:did_ftplugin')
 endif
 let b:did_ftplugin = 1
 
+set wildignore+=*.olean
+
 setlocal iskeyword=@,48-57,_,-,!,#,$,%
 
 setlocal comments=s0:/-,mb:\ ,ex:-/,:--


### PR DESCRIPTION
I don't know that I've seen ftplugins do this by default, but it looks like at least [python.vim does so](https://github.com/neovim/neovim/blob/f6ac375604238c94d3dc3eeb9b82e67417460806/runtime/ftplugin/python.vim#L46)